### PR TITLE
Created a class to resolve a wildcard event name

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -2,3 +2,4 @@
 --color
 --fail-fast
 --order rand
+--require spec_helper

--- a/lib/basquiat/adapters/base_adapter.rb
+++ b/lib/basquiat/adapters/base_adapter.rb
@@ -6,7 +6,7 @@ module Basquiat
 
       def initialize
         @options = base_options
-        @procs   = {}
+        @procs   = Basquiat::Events.new
         @retries = 0
       end
 

--- a/lib/basquiat/support.rb
+++ b/lib/basquiat/support.rb
@@ -1,3 +1,4 @@
 require 'basquiat/support/hash_refinements'
 require 'basquiat/support/configuration'
 require 'basquiat/support/json'
+require 'basquiat/support/events'

--- a/lib/basquiat/support/events.rb
+++ b/lib/basquiat/support/events.rb
@@ -1,0 +1,24 @@
+module Basquiat
+  class Events
+    extend Forwardable
+
+    attr_reader :internal_events
+
+    def_delegator :internal_events, :keys
+
+    def initialize
+      @internal_events = {}
+    end
+
+    def []=(key, value)
+      internal_events[key] = value
+    end
+
+    def [](key)
+      unless internal_events.key?(key)
+        key = internal_events.keys.select { |event| Regexp.new(event.gsub('#', '*')).match(key) }.first
+      end
+      internal_events[key]
+    end
+  end
+end

--- a/spec/lib/adapters/rabbitmq_adapter_spec.rb
+++ b/spec/lib/adapters/rabbitmq_adapter_spec.rb
@@ -67,6 +67,22 @@ describe Basquiat::Adapters::RabbitMq do
 
       expect(message_received).to eq(data: 'COISA')
     end
+
+    it '#subscribe_to other event with #' do
+      message_received = ''
+      subject.subscribe_to('other.event.#',
+                           lambda do |msg|
+                             msg[:data].upcase!
+                             message_received = msg
+                           end)
+      subject.listen(block: false)
+
+      subject.publish('other.event.extra', data: 'outra coisa')
+      sleep 0.1 # Wait for the listening thread.
+
+      expect(message_received).to eq(data: 'OUTRA COISA')
+    end
+
   end
 
   def remove_queues_and_exchanges

--- a/spec/lib/support/events_spec.rb
+++ b/spec/lib/support/events_spec.rb
@@ -1,0 +1,9 @@
+describe Basquiat::Events do
+
+  it 'add a key with # and retrive like a wildcard' do
+    events = Basquiat::Events.new
+
+    events['one.key.#'] = 'some'
+    expect(events['one.key.extra']).to eql('some')
+  end
+end


### PR DESCRIPTION
When declarated a event with wildcard #, like: event.name.#
This events were not found in hash.
To avoid this, an object was created to simulate hash and find the event
name with correct name like: event.name.something