### PR TITLE
Adjusting safe_load to receive Symbol as parse class

### DIFF
--- a/lib/basquiat/support/configuration.rb
+++ b/lib/basquiat/support/configuration.rb
@@ -82,7 +82,7 @@ module Basquiat
     end
 
     def load_yaml(path)
-      @yaml = YAML.safe_load(ERB.new(IO.readlines(path).join).result).symbolize_keys
+      @yaml = YAML.safe_load(ERB.new(IO.readlines(path).join).result, [Symbol]).symbolize_keys
     end
 
     def setup_basic_options

--- a/lib/basquiat/version.rb
+++ b/lib/basquiat/version.rb
@@ -2,5 +2,5 @@
 
 # Version file
 module Basquiat
-  VERSION = '1.3.4'
+  VERSION = '1.3.6'
 end

--- a/spec/lib/support/configuration_spec.rb
+++ b/spec/lib/support/configuration_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Basquiat::Configuration do
     expect(config.queue_name).to eq('my.nice_queue')
     expect(config.exchange_name).to eq('my.test_exchange')
     expect(config.default_adapter).to eq('Basquiat::Adapters::Test')
-    expect(config.adapter_options).to have_key(:servers)
+    expect(config.adapter_options).to have_key(:connection)
   end
 
   it 'settings provided on the config file have lower precedence' do

--- a/spec/support/basquiat.yml
+++ b/spec/support/basquiat.yml
@@ -3,7 +3,16 @@ test:
   queue_name: 'my.nice_queue'
   default_adapter: Basquiat::Adapters::Test
   adapter_options:
-      servers:
-        -
-          host: <%= ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_ADDR') { 'localhost' } %>
-          port: <%= ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_PORT') { 5672 } %>
+    connection:
+      hosts:
+        - <%= ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_ADDR') { 'localhost' } %>
+      port: <%= ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_PORT') { 5672 } %>
+      auth:
+        user: 'guest'
+        password: 'guest'
+    consumer:
+      prefetch: 1
+      manual_ack: true
+    requeue:
+      enabled: true
+      strategy: basic_ack


### PR DESCRIPTION
- Update line command of YAML.safe_load to receive Symbol as possible parser
- Adjusting basquiat.yml to keep interface like expected with hosts and not servers