### PR TITLE
Connection pool of sessions for publishing messages from multiple threads

### DIFF
--- a/basquiat.gemspec
+++ b/basquiat.gemspec
@@ -30,6 +30,7 @@ EOD
   spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'guard-yard'
   spec.add_development_dependency 'bunny'
+  spec.add_development_dependency 'connection_pool'
   spec.add_development_dependency 'yajl-ruby'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'rubocop'

--- a/basquiat.gemspec
+++ b/basquiat.gemspec
@@ -30,7 +30,6 @@ EOD
   spec.add_development_dependency 'guard-rubocop'
   spec.add_development_dependency 'guard-yard'
   spec.add_development_dependency 'bunny'
-  spec.add_development_dependency 'connection_pool'
   spec.add_development_dependency 'yajl-ruby'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'rubocop'
@@ -38,6 +37,7 @@ EOD
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'yard'
 
+  spec.add_dependency 'connection_pool'
   spec.add_dependency 'multi_json'
   spec.add_dependency 'naught'
 end

--- a/lib/basquiat.rb
+++ b/lib/basquiat.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'connection_pool'
 require 'multi_json'
 require 'naught'
 require 'yaml'

--- a/lib/basquiat/adapters/rabbitmq/configuration.rb
+++ b/lib/basquiat/adapters/rabbitmq/configuration.rb
@@ -22,7 +22,7 @@ module Basquiat
                          durable: true,
                          options: {}
                        },
-                       publisher: { confirm: true, persistent: false, session_pool: nil },
+                       publisher: { confirm: true, persistent: false, session_pool: { size: 1, timeout: 5 } },
                        consumer: { prefetch: 1000, manual_ack: true },
                        requeue: { enabled: false } }
         end

--- a/lib/basquiat/adapters/rabbitmq/configuration.rb
+++ b/lib/basquiat/adapters/rabbitmq/configuration.rb
@@ -22,7 +22,7 @@ module Basquiat
                          durable: true,
                          options: {}
                        },
-                       publisher: { confirm: true, persistent: false },
+                       publisher: { confirm: true, persistent: false, session_pool: nil },
                        consumer: { prefetch: 1000, manual_ack: true },
                        requeue: { enabled: false } }
         end

--- a/lib/basquiat/adapters/rabbitmq_adapter.rb
+++ b/lib/basquiat/adapters/rabbitmq_adapter.rb
@@ -43,11 +43,7 @@ module Basquiat
       # @param message [Hash] the message to be publish
       # @param props [Hash] other properties you wish to publish with the message, such as custom headers etc.
       def publish(event, message, props: {})
-        if options[:publisher][:session_pool]
-          session_pool.with { |session| session.publish(event, message, props) }
-        else
-          session.publish(event, message, props)
-        end
+        session_pool.with { |session| session.publish(event, message, props) }
         disconnect unless options[:publisher][:persistent]
       end
 

--- a/lib/basquiat/adapters/rabbitmq_adapter.rb
+++ b/lib/basquiat/adapters/rabbitmq_adapter.rb
@@ -43,7 +43,11 @@ module Basquiat
       # @param message [Hash] the message to be publish
       # @param props [Hash] other properties you wish to publish with the message, such as custom headers etc.
       def publish(event, message, props: {})
-        session.publish(event, message, props)
+        if options[:publisher][:session_pool]
+          session_pool.with { |session| session.publish(event, message, props) }
+        else
+          session.publish(event, message, props)
+        end
         disconnect unless options[:publisher][:persistent]
       end
 
@@ -67,9 +71,10 @@ module Basquiat
       # Reset the connection to RabbitMQ.
       def reset_connection
         connection.disconnect
-        @connection = nil
-        @session    = nil
-        @strategy   = nil
+        @connection   = nil
+        @session      = nil
+        @session_pool = nil
+        @strategy     = nil
       end
 
       alias disconnect reset_connection
@@ -84,6 +89,15 @@ module Basquiat
       # @return [Session]
       def session
         @session ||= Session.new(connection.create_channel, @configuration.session_options)
+      end
+
+      # Lazy initializes and return the session pool
+      # @return [ConnectionPool<Session>]
+      def session_pool
+        @session_pool ||= ConnectionPool.new(size: options[:publisher][:session_pool][:size],
+                                             timeout: options[:publisher][:session_pool][:timeout]) do
+          Session.new(connection.create_channel, @configuration.session_options)
+        end
       end
 
       private

--- a/lib/basquiat/version.rb
+++ b/lib/basquiat/version.rb
@@ -2,5 +2,5 @@
 
 # Version file
 module Basquiat
-  VERSION = '1.3.6'
+  VERSION = '1.4.0'
 end

--- a/lib/basquiat/version.rb
+++ b/lib/basquiat/version.rb
@@ -2,5 +2,5 @@
 
 # Version file
 module Basquiat
-  VERSION = '1.4.0'
+  VERSION = '1.3.7'
 end

--- a/lib/basquiat/version.rb
+++ b/lib/basquiat/version.rb
@@ -2,5 +2,5 @@
 
 # Version file
 module Basquiat
-  VERSION = '1.3.7'
+  VERSION = '1.4.0'
 end

--- a/spec/lib/adapters/rabbitmq_adapter_spec.rb
+++ b/spec/lib/adapters/rabbitmq_adapter_spec.rb
@@ -22,10 +22,26 @@ RSpec.describe Basquiat::Adapters::RabbitMq do
     end
 
     context 'publisher' do
-      it '#publish [enqueue a message]' do
-        expect do
-          adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
-        end.to_not raise_error
+      context 'with session pool' do
+        let(:base_options) do
+          { connection: { hosts: [ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_ADDR') { 'localhost' }],
+                          port:  ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_PORT') { 5672 } },
+            publisher: { persistent: true, session_pool: { size: 1, timeout: 5 } } }
+        end
+
+        it '#publish [enqueue a message]' do
+          expect do
+            adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
+          end.to_not raise_error
+        end
+      end
+
+      context 'without session pool' do
+        it '#publish [enqueue a message]' do
+          expect do
+            adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
+          end.to_not raise_error
+        end
       end
     end
 

--- a/spec/lib/adapters/rabbitmq_adapter_spec.rb
+++ b/spec/lib/adapters/rabbitmq_adapter_spec.rb
@@ -22,26 +22,10 @@ RSpec.describe Basquiat::Adapters::RabbitMq do
     end
 
     context 'publisher' do
-      context 'with session pool' do
-        let(:base_options) do
-          { connection: { hosts: [ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_ADDR') { 'localhost' }],
-                          port:  ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_PORT') { 5672 } },
-            publisher: { persistent: true, session_pool: { size: 1, timeout: 5 } } }
-        end
-
-        it '#publish [enqueue a message]' do
-          expect do
-            adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
-          end.to_not raise_error
-        end
-      end
-
-      context 'without session pool' do
-        it '#publish [enqueue a message]' do
-          expect do
-            adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
-          end.to_not raise_error
-        end
+      it '#publish [enqueue a message]' do
+        expect do
+          adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
+        end.to_not raise_error
       end
     end
 

--- a/spec/lib/adapters/rabbitmq_adapter_spec.rb
+++ b/spec/lib/adapters/rabbitmq_adapter_spec.rb
@@ -22,10 +22,32 @@ RSpec.describe Basquiat::Adapters::RabbitMq do
     end
 
     context 'publisher' do
-      it '#publish [enqueue a message]' do
-        expect do
-          adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
-        end.to_not raise_error
+      context 'main process' do
+        it '#publish [enqueue a message]' do
+          expect do
+            adapter.publish('messages.welcome', data: 'A Nice Welcome Message')
+          end.to_not raise_error
+        end
+      end
+
+      context 'multiple threads' do
+        let(:base_options) do
+          { connection: { hosts: [ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_ADDR') { 'localhost' }],
+                          port:  ENV.fetch('BASQUIAT_RABBITMQ_1_PORT_5672_TCP_PORT') { 5672 } },
+            publisher: { persistent: true, session_pool: { size: 10 } } }
+        end
+
+        it '#publish [enqueue a message 10 times concurrently]' do
+          expect do
+            threads = []
+
+            10.times do
+              threads << Thread.new { adapter.publish('messages.welcome', data: 'A Nice Welcome Message') }
+            end
+
+            threads.each(&:join)
+          end.not_to raise_error
+        end
       end
     end
 


### PR DESCRIPTION
To be able to publish messages using webservers like [puma](https://github.com/puma/puma), if we have more than one thread defined per forked workers, the same connection can be shared between the threads of a worker, but each thread must have its own channel, as described in [Sharing Channels Between Threads](http://rubybunny.info/articles/concurrency.html#sharing_channels_between_threads).

This PR uses the [connection_pool](https://github.com/mperham/connection_pool) gem to manage a pool of basquiat rabbitmq sessions (each session has its own channel).

The "session_pool" is only used for publishing messages. For consumers, bunny already provides [consumer work pools](http://rubybunny.info/articles/concurrency.html#consumer_work_pools).