### PR TITLE
  [Fix] Adds support for YAML aliases in config

### DIFF
--- a/lib/basquiat/support/configuration.rb
+++ b/lib/basquiat/support/configuration.rb
@@ -84,7 +84,7 @@ module Basquiat
     end
 
     def load_yaml(path)
-      @yaml = YAML.safe_load(ERB.new(IO.readlines(path).join).result, [Symbol]).symbolize_keys
+      @yaml = YAML.safe_load(ERB.new(IO.readlines(path).join).result, [Symbol], [], true).symbolize_keys
     end
 
     def setup_basic_options

--- a/lib/basquiat/version.rb
+++ b/lib/basquiat/version.rb
@@ -2,5 +2,5 @@
 
 # Version file
 module Basquiat
-  VERSION = '1.5.0'
+  VERSION = '1.5.1'
 end

--- a/spec/support/basquiat.yml
+++ b/spec/support/basquiat.yml
@@ -1,4 +1,11 @@
-test:
+failure_options: &failure_options
+  failover:
+    default_timeout: 1
+    read_timeout: 5
+    write_timeout: 3
+    max_retries: 3
+
+test: &test
   exchange_name: 'my.test_exchange'
   queue_name: 'my.nice_queue'
   default_adapter: Basquiat::Adapters::Test
@@ -10,6 +17,7 @@ test:
       auth:
         user: 'guest'
         password: 'guest'
+      <<: *failure_options
     consumer:
       prefetch: 1
       manual_ack: true


### PR DESCRIPTION
  * Change basquiat.yml fixture
  * Change Configuration#load_yaml

Adds true option to enable aliases in Psych: https://ruby-doc.org/stdlib-2.1.3/libdoc/psych/rdoc/Psych.html#method-c-safe_load