### PR TITLE
Adding TLS support + vhost configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ development:                                #full example of the RabbitMq option
       auth:
         user: 'guest'
         password: 'guest'
+      tls_options:
+        tls: false
     publisher:
       confirm: true
       persistent: true

--- a/lib/basquiat/version.rb
+++ b/lib/basquiat/version.rb
@@ -2,5 +2,5 @@
 
 # Version file
 module Basquiat
-  VERSION = '1.5.2'
+  VERSION = '1.6.0'
 end


### PR DESCRIPTION
Adding support to TLS and vhost in the basquiat.yml configuration file.

Example:

```yaml
development:
  exchange_name: 'basquiat.exchange'
  queue_name: 'basquiat.queue'
  default_adapter: Basquiat::Adapters::RabbitMq
  adapter_options:
    connection:
      hosts:
        - 'localhost'
      port: 5672
      vhost: '/'
      auth:
        user: 'guest'
        password: 'guest'
      tls_options:
        tls: false
```
